### PR TITLE
Fix recursion in dirtyReactive()

### DIFF
--- a/dart/dynamics/BodyNode.cpp
+++ b/dart/dynamics/BodyNode.cpp
@@ -1634,12 +1634,9 @@ void BodyNode::dirtyReactive()
     BodyNode* current = descendents.back();
     descendents.pop_back();
 
-    if (!current->mIsReactiveDirty)
-    {
-      current->mIsReactiveDirty = true;
-      for(BodyNode* child : mChildBodyNodes)
-        descendents.push_back(child);
-    }
+    current->mIsReactiveDirty = true;
+    for (BodyNode* child : current->mChildBodyNodes)
+      descendents.push_back(child);
   }
 }
 


### PR DESCRIPTION
This bug was giving me a bit of an existential crisis, because I was so certain that I made the parent/child structure management in DART air-tight, and trying to figure out how there could ever be a cyclical parent/child structure was sending my brain into a tailspin.

Then I realized I simply forgot a `current->` in this function :weary: 