### PR TITLE
Fix grouping of contact constraints

### DIFF
--- a/dart/constraint/BoxedLcpConstraintSolver.cpp
+++ b/dart/constraint/BoxedLcpConstraintSolver.cpp
@@ -169,7 +169,7 @@ void BoxedLcpConstraintSolver::solveConstrainedGroup(ConstrainedGroup& group)
   mFIndex.setConstant(n, -1); // set findex to -1
 
   // Compute offset indices
-  mOffset.resize(n);
+  mOffset.setZero(numConstraints);
   mOffset[0] = 0;
   for (std::size_t i = 1; i < numConstraints; ++i)
   {

--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -893,9 +893,9 @@ dynamics::SkeletonPtr ContactConstraint::getRootSkeleton() const
   assert(isActive());
 
   if (mBodyNodeA->isReactive())
-    return mBodyNodeA->getSkeleton()->mUnionRootSkeleton.lock();
+    return ConstraintBase::getRootSkeleton(mBodyNodeA->getSkeleton());
   else
-    return mBodyNodeB->getSkeleton()->mUnionRootSkeleton.lock();
+    return ConstraintBase::getRootSkeleton(mBodyNodeB->getSkeleton());
 }
 
 //==============================================================================


### PR DESCRIPTION
DART crashes when simulating a modest number of objects that come into contact with each other. 

To test, run the following file in ign-gazebo (`ign gazebo -v 4 cube5.sdf.txt`)
[cube5.sdf.txt](https://github.com/azeey/dart/files/4755483/cube5.sdf.txt) (courtesy of @mjcarroll)

Before the PR, ign-gazebo crashes with
```
ODE INTERNAL ERROR 1: assertion "bNormalizationResult" failed in _dNormalize4() [odemath.h:42]
```
![Peek 2020-06-09 19-22-crash](https://user-images.githubusercontent.com/206116/84213599-b5c2bf00-aa86-11ea-875d-38b53c34feb9.gif)

With the PR:
![Peek 2020-06-09 19-23](https://user-images.githubusercontent.com/206116/84213646-d4c15100-aa86-11ea-9054-2e944f4f0860.gif)


For a given set of contact constraints, the constraint solver first creates a grouping of related constraints, and then solves each group independently. There seems to be a problem with this grouping and some constraints end up being in two groups. 

The `ContactConstraint::uniteSkeleton` function unites two skeletons associated with a given contact constraint. It does that by setting the `mUnionRootSkeleton` member of one of the skeletons to point to the current root skeleton of the second skeleton. To decide which of the two skeletons' root node becomes the new union's root node, the size of the skeletons' current unions are compared.

As an example, let `A`,`B`,`C`, and `D` be skeletons associated with 3 contact constraints. When `ContactConstraint::uniteSkeleton` is called for constraints 1 and 2, skeleton `B` is chosen to be the root node.
```
1. A, B = A -> B
2. C, A = C -> B // Since the root of A is B, C's mUnionRootSkeleton now points to B
3. D, B = B -> D // Let's assume D is chosen because D's union size is larger.
```
When `D` is chosen for constraint 3, `A` and `C` are not updated. Thus, later on when `ContactConstraing::getRootSkeleton` is called on constraint 1 or 2, `B` is returned instead of `D`. This results in error in the grouping of constraints.

It's not clear to me why this error causes a crash, but the hint that led me to a solution is that I tried disabling the grouping altogether and letting all the constraints be solved in a single call to `ConstraingSolver::solveConstrainedGroup` and that didn't crash. My guess is that when a constraint ends up in two groups, a solution for that constraint is computed twice and the resulting impulses are erroneously accumulated.

I'm not sure how to properly/reliably test this as it seems to occur randomly. 

/cc @scpeters, @mxgrey