### PR TITLE
More integration fixes

### DIFF
--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -589,15 +589,28 @@ bool FreeJoint::isCyclic(std::size_t _index) const
 //==============================================================================
 void FreeJoint::integratePositions(double _dt)
 {
-  const Eigen::Isometry3d Qdiff
-      =  convertToTransform(getVelocitiesStatic() * _dt);
-  const Eigen::Isometry3d Qnext = getQ()* Qdiff;
+  const Eigen::Vector6d& vel = getVelocitiesStatic();
+  const Eigen::Vector6d& accel = getAccelerationsStatic();
+  auto *bn = getChildBodyNode();
+  Eigen::Isometry3d Tcom;
+  // Transform from joint to center of mass of child body
+  Tcom = Eigen::Translation3d(
+      Joint::mAspectProperties.mT_ChildBodyToJoint.inverse()
+      * bn->getLocalCOM());
+  auto velAtCom = math::AdT(Tcom.inverse(), vel);
+  auto accelAtCom = math::AdT(Tcom.inverse(), accel);
 
-  // This is setVelocitiesStatic(math::AdR(Qnext.inverse() * getQ(), vel)), but
-  // using Qdiff instead.
-  setVelocitiesStatic(math::AdR(Qdiff.inverse(), getVelocitiesStatic()));
-  setAccelerationsStatic(math::AdR(Qdiff.inverse(), getAccelerationsStatic()));
+  const Eigen::Isometry3d Qcom = getQ() * Tcom;
+  const Eigen::Isometry3d Qdiff = convertToTransform(velAtCom * _dt);
 
+  const Eigen::Vector6d newVelAtCom = math::AdR(Qdiff.inverse(), velAtCom);
+  const Eigen::Vector6d newAccelAtCom = math::AdR(Qdiff.inverse(), accelAtCom);
+
+  const Eigen::Isometry3d QnextAtCom = Qcom * Qdiff;
+  const Eigen::Isometry3d Qnext = QnextAtCom * Tcom.inverse();
+
+  setVelocitiesStatic(math::AdT(Tcom, newVelAtCom));
+  setAccelerationsStatic(math::AdT(Tcom, newAccelAtCom));
   setPositionsStatic(convertToPositions(Qnext));
 }
 
@@ -608,14 +621,47 @@ void FreeJoint::integrateVelocities(double _dt)
   // Acceleration with additional term to take into account changing linear
   // velocity in the inertial frame.
   Eigen::Vector6d accelWithInertialTerm = getAccelerationsStatic();
-  accelWithInertialTerm.tail<3>() += (vel.head<3>().cross(vel.tail<3>()));
+
+  // Not sure if we need a different inertia than the one from the child body
+  // node.
+  const Eigen::Matrix6d& mI = getChildBodyNode()->getSpatialInertia();
+  const Eigen::Matrix6d& artInvProjI = getInvProjArtInertia();
+  // Remove Coriolis term because the velocity will be updated when integrating
+  // position and that will account for the rotation of the frame.
+  accelWithInertialTerm.tail<3>()
+      -= (artInvProjI * math::dad(vel, mI * vel)).tail<3>();
 
   setVelocitiesStatic(math::integrateVelocity<math::SE3Space>(
-      getVelocitiesStatic(), accelWithInertialTerm,  _dt));
+      getVelocitiesStatic(), accelWithInertialTerm, _dt));
   // vel now points to the updated velocity
-  Eigen::Vector6d accel = accelWithInertialTerm;
-  accel.tail<3>() -= vel.head<3>().cross(vel.tail<3>());
-  setAccelerationsStatic(accel);
+  accelWithInertialTerm.tail<3>()
+      += (artInvProjI * math::dad(vel, mI * vel)).tail<3>();
+  setAccelerationsStatic(accelWithInertialTerm);
+}
+
+void FreeJoint::updateConstrainedTerms(double timeStep)
+{
+  const double invTimeStep = 1.0 / timeStep;
+
+  const Eigen::Vector6d& vel = getVelocitiesStatic();
+  Eigen::Vector6d accelWithInertialTerm = getAccelerationsStatic();
+  const Eigen::Matrix6d& mI = getChildBodyNode()->getSpatialInertia();
+  const Eigen::Matrix6d& artInvI = getInvProjArtInertia();
+  // Remove Coriolis term because the velocity will be updated when integrating
+  // position and that will account for the rotation of the frame.
+  accelWithInertialTerm.tail<3>()
+      -= (artInvI * math::dad(vel, mI * vel)).tail<3>();
+
+  setVelocitiesStatic(getVelocitiesStatic() + mVelocityChanges);
+
+  // vel now points to the updated velocity
+  accelWithInertialTerm.tail<3>()
+      += (artInvI * math::dad(vel, mI * vel)).tail<3>();
+  setAccelerationsStatic(
+      accelWithInertialTerm + mVelocityChanges * invTimeStep);
+
+  this->mAspectState.mForces.noalias() += mImpulses * invTimeStep;
+  // Note: As long as this is only called from BodyNode::updateConstrainedTerms
 }
 
 //==============================================================================

--- a/dart/dynamics/FreeJoint.cpp
+++ b/dart/dynamics/FreeJoint.cpp
@@ -591,7 +591,7 @@ void FreeJoint::integratePositions(double _dt)
 {
   const Eigen::Vector6d& vel = getVelocitiesStatic();
   const Eigen::Vector6d& accel = getAccelerationsStatic();
-  auto *bn = getChildBodyNode();
+  auto* bn = getChildBodyNode();
   Eigen::Isometry3d Tcom;
   // Transform from joint to center of mass of child body
   Tcom = Eigen::Translation3d(

--- a/dart/dynamics/FreeJoint.hpp
+++ b/dart/dynamics/FreeJoint.hpp
@@ -334,6 +334,9 @@ protected:
   void integrateVelocities(double _dt) override;
 
   // Documentation inherited
+  void updateConstrainedTerms(double timeStep) override;
+
+  // Documentation inherited
   void updateDegreeOfFreedomNames() override;
 
   // Documentation inherited

--- a/unittests/comprehensive/test_Dynamics.cpp
+++ b/unittests/comprehensive/test_Dynamics.cpp
@@ -2512,3 +2512,64 @@ TEST_F(DynamicsTest, HybridDynamics)
     EXPECT_NEAR(command(i, 4), output(i, 4), tol);
   }
 }
+
+//==============================================================================
+TEST_F(DynamicsTest, OffsetCOM)
+{
+  WorldPtr world = World::create();
+  ASSERT_TRUE(world != nullptr);
+  world->setGravity(Eigen::Vector3d(0.0, 0.0, 0.0));
+  const double dt = 0.001;
+  world->setTimeStep(dt);
+
+  SkeletonPtr boxSkel = createBox(Vector3d(1.0, 1.0, 1.0));
+  world->addSkeleton(boxSkel);
+  BodyNode* box = boxSkel->getBodyNode(0);
+  dynamics::Inertia inertia;
+  inertia.setMass(60);
+  inertia.setMoment(
+      box->getShapeNode(0)->getShape()->computeInertia(inertia.getMass()));
+  inertia.setLocalCOM({0, 500, 0});
+  box->setInertia(inertia);
+  box->addExtTorque({0, 0, 100}, false);
+
+  {
+    Vector3d comVel = box->getCOMLinearVelocity();
+    EXPECT_TRUE(equals(Vector3d(0, 0, 0), comVel))
+        << "comVel: " << comVel.transpose();
+  }
+  {
+    Vector3d linVel = box->getLinearVelocity();
+    EXPECT_TRUE(equals(Vector3d(0, 0, 0), linVel))
+        << "linVel: " << linVel.transpose();
+  }
+
+  world->step();
+  // Velocity at COM should be zero since the object is just rotating.
+  {
+    Vector3d comVel = box->getCOMLinearVelocity();
+    EXPECT_TRUE(equals(Vector3d(0, 0, 0), comVel))
+        << "comVel: " << comVel.transpose();
+  }
+  {
+    Vector3d angVel = box->getAngularVelocity();
+    EXPECT_TRUE(equals(Vector3d(0, 0, 0.01), angVel))
+        << "angVel: " << angVel.transpose();
+    Vector3d linVel = box->getLinearVelocity();
+    Vector3d expLinVel
+        = angVel.cross(box->getWorldTransform().linear() * -box->getLocalCOM());
+    EXPECT_TRUE(equals(expLinVel, linVel))
+        << "Expected: " << expLinVel.transpose()
+        << "\nActual: " << linVel.transpose();
+
+    Vector3d angAccel = box->getAngularAcceleration();
+    EXPECT_TRUE(equals(Vector3d(0, 0, 10), angAccel))
+        << "angAccel: " << angAccel.transpose();
+    Vector3d linAccel = box->getLinearAcceleration();
+    Vector3d expLinAccel = angVel.cross(linVel) + angAccel.cross(
+        box->getWorldTransform().linear() * -box->getLocalCOM());
+    EXPECT_TRUE(equals(expLinAccel, linAccel))
+        << "Expected: " << expLinAccel.transpose()
+        << "\nActual: " << linAccel.transpose();
+  }
+}

--- a/unittests/comprehensive/test_Dynamics.cpp
+++ b/unittests/comprehensive/test_Dynamics.cpp
@@ -2566,8 +2566,10 @@ TEST_F(DynamicsTest, OffsetCOM)
     EXPECT_TRUE(equals(Vector3d(0, 0, 10), angAccel))
         << "angAccel: " << angAccel.transpose();
     Vector3d linAccel = box->getLinearAcceleration();
-    Vector3d expLinAccel = angVel.cross(linVel) + angAccel.cross(
-        box->getWorldTransform().linear() * -box->getLocalCOM());
+    Vector3d expLinAccel
+        = angVel.cross(linVel)
+          + angAccel.cross(
+                box->getWorldTransform().linear() * -box->getLocalCOM());
     EXPECT_TRUE(equals(expLinAccel, linAccel))
         << "Expected: " << expLinAccel.transpose()
         << "\nActual: " << linAccel.transpose();


### PR DESCRIPTION
While working on #9 , I found that `getLinearAcceleration` did not return the correct value. Investigating that further, I found that the integration fix in #5 did not apply when constraint impulses are involved. Furthermore, I found problems with the integration of position in `FreeJoint::integratePosition` when the COM of a body is not at the origin. This PR fixes both issues and adds a test for the COM offset issue. I wasn't able to create a simple test for the first issue, but I will update #9 to use `getLinearAcceleration` in the test.

The linear acceleration issue is fixed by a Coriolis term from the acceleration before integrating it to obtain a new velocity. My intuition for this is that the `FreeJoint::integratePosition` updates the spatial velocity based on the newly integrated position. This update to spatial velocity is in itself an acceleration and it does what the Coriolis term would have done had we `FreeJoint::integratePosition` not updated the spatial velocity.

The COM offset issue is fixed by transforming all quantities into the COM frame before integration. After integration, the values are transformed back into the body's origin frame.

I have tested this PR with Gazebo-classic and it fixes the test `AddForce` test in `INTEGRATION_physics_link`. I was even able to remove the tolerance adjustment in https://github.com/osrf/gazebo/blob/a9f093f2fc7fa7fc49efa73719f6536ad28f8af7/test/integration/physics_link.cc#L164