### PR TITLE
Add [gs]etPrimarySlipCompliance API

### DIFF
--- a/dart/dynamics/ShapeFrame.cpp
+++ b/dart/dynamics/ShapeFrame.cpp
@@ -184,6 +184,18 @@ DynamicsAspect::DynamicsAspect(const PropertiesData& properties)
 }
 
 //==============================================================================
+void DynamicsAspect::setPrimarySlipCompliance(const double& value)
+{
+  mProperties.mSlipCompliance = value;
+}
+
+//==============================================================================
+const double& DynamicsAspect::getPrimarySlipCompliance() const
+{
+  return mProperties.mSlipCompliance;
+}
+
+//==============================================================================
 void DynamicsAspect::setFirstFrictionDirectionFrame(const Frame* value)
 {
   mProperties.mFirstFrictionDirectionFrame = value;

--- a/dart/dynamics/ShapeFrame.hpp
+++ b/dart/dynamics/ShapeFrame.hpp
@@ -161,6 +161,9 @@ public:
   DART_COMMON_SET_GET_ASPECT_PROPERTY( double, SlipCompliance )
   // void setSlipCompliance(const double& value);
   // const double& getSlipCompliance() const;
+  // Support API that matches upstream 6.10.0 release as well
+  void setPrimarySlipCompliance(const double& value);
+  const double& getPrimarySlipCompliance() const;
   DART_COMMON_SET_GET_ASPECT_PROPERTY( double, SecondarySlipCompliance )
   // void setSecondarySlipCompliance(const double& value);
   // const double& getSecondarySlipCompliance() const;

--- a/unittests/comprehensive/test_ForceDependentSlip.cpp
+++ b/unittests/comprehensive/test_ForceDependentSlip.cpp
@@ -117,9 +117,10 @@ TEST(ForceDependentSlip, BoxSlipVelocity)
 
   EXPECT_DOUBLE_EQ(body1Dynamics->getFrictionCoeff(), 1.0);
 
-  body1Dynamics->setSlipCompliance(slip);
+  body1Dynamics->setPrimarySlipCompliance(slip);
   body1Dynamics->setFirstFrictionDirection(Vector3d::UnitX());
   EXPECT_DOUBLE_EQ(body1Dynamics->getSlipCompliance(), slip);
+  EXPECT_DOUBLE_EQ(body1Dynamics->getPrimarySlipCompliance(), slip);
   EXPECT_EQ(body1Dynamics->getFirstFrictionDirection(), Vector3d::UnitX());
 
   auto body2 = skeleton2->getRootBodyNode();
@@ -157,10 +158,11 @@ TEST(ForceDependentSlip, BoxSlipVelocity)
 
   const double slip2 = 0.03;
   // Test slip compliance in the secondary friction direction
-  body1Dynamics->setSlipCompliance(0);
+  body1Dynamics->setPrimarySlipCompliance(0);
   body1Dynamics->setSecondarySlipCompliance(slip2);
 
   EXPECT_DOUBLE_EQ(body1Dynamics->getSlipCompliance(), 0.0);
+  EXPECT_DOUBLE_EQ(body1Dynamics->getPrimarySlipCompliance(), 0.0);
   EXPECT_DOUBLE_EQ(body1Dynamics->getSecondarySlipCompliance(), slip2);
 
   // Step without external force so the body stop moving
@@ -221,6 +223,7 @@ TEST(ForceDependentSlip, CylinderSlipVelocity)
   body1Dynamics->setSlipCompliance(slip);
   body1Dynamics->setFirstFrictionDirection(Vector3d::UnitX());
   EXPECT_DOUBLE_EQ(body1Dynamics->getSlipCompliance(), slip);
+  EXPECT_DOUBLE_EQ(body1Dynamics->getPrimarySlipCompliance(), slip);
   EXPECT_EQ(body1Dynamics->getFirstFrictionDirection(), Vector3d::UnitX());
 
   auto body2 = skeleton2->getRootBodyNode();


### PR DESCRIPTION
Keep the exising API but add the API used upstream so both can be supported. Required by https://github.com/ignitionrobotics/ign-physics/pull/249.

***

**Before creating a pull request**

- [ ] Document new methods and classes
- [ ] Format new code files using `clang-format`

**Before merging a pull request**

- [ ] Set version target by selecting a milestone on the right side
- [ ] Summarize this change in `CHANGELOG.md`
- [ ] Add unit test(s) for this change
