### PR TITLE
Add define to indicate positive sign of contact surface motion velocities

### DIFF
--- a/dart/constraint/ContactConstraint.cpp
+++ b/dart/constraint/ContactConstraint.cpp
@@ -794,6 +794,9 @@ ContactConstraint::getTangentBasisMatrixODE(const Eigen::Vector3d& n)
 
   // Pick an arbitrary vector to take the cross product of (in this case,
   // Z-axis)
+  // Note: The upstream version of DART uses the opposite order of operands for
+  // this cross-product. Hence, the sign convention for contact surface motion
+  // velocities has to be inverted (see the note in ContactSurface.hpp).
   Eigen::Vector3d tangent = mFirstFrictionalDirection.cross(n);
 
   // TODO(JS): Modify following lines once _updateFirstFrictionalDirection() is

--- a/dart/constraint/ContactSurface.hpp
+++ b/dart/constraint/ContactSurface.hpp
@@ -38,6 +38,15 @@
 #include "dart/dynamics/ShapeNode.hpp"
 #include "dart/constraint/SmartPointer.hpp"
 
+// The implementation of ContactConstraint::getTangentBasisMatrixODE in the
+// upstream version of DART uses a different sign convention. This define is
+// used to conditionally negate contact surface motion velocities if the down
+// stream library is using the upstream DART implementation. If forward porting
+// to or merging from upstream DART, be sure to remove this define if the
+// implementation in ContactConstraint::getTangentBasisMatrixODE matches the
+// upstream version after the port.
+#define DART_HAS_POSITIVE_CONTACT_SURFACE_MOTION_VELOCITY
+
 namespace dart {
 namespace constraint {
 

--- a/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
+++ b/examples/deprecated_examples/glut_human_joint_limits/CMakeLists.txt
@@ -34,11 +34,10 @@ set(required_libraries
 )
 
 if(DART_IN_SOURCE_BUILD)
-    dart_build_example_in_source(${example_name}
-      LINK_LIBRARIES ${required_libraries}
-      COMPILE_FEATURES cxx_std_14
-    )
-  endif()
+  dart_build_example_in_source(${example_name}
+    LINK_LIBRARIES ${required_libraries}
+    COMPILE_FEATURES cxx_std_14
+  )
   return()
 endif()
 


### PR DESCRIPTION
Toward https://github.com/gazebosim/gz-sim/issues/2008

This adds a define to indicate that this is not the upstream implementation of contact surface motion velocities. See comments in the code for more details.