### PR TITLE
Fix build with urdfdom 4.0.0

### DIFF
--- a/dart/utils/urdf/urdf_world_parser.cpp
+++ b/dart/utils/urdf/urdf_world_parser.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<World> parseWorldURDF(
           auto* origin = entity_xml->FirstChildElement("origin");
           if( origin )
           {
-            if( !parsePose( entity.origin, origin ) )
+            if( !urdf_parsing::parsePose( entity.origin, origin ) )
             {
               dtwarn << "[ERROR] Missing origin tag for '" << entity.model->getName() << "'\n";
               return world;


### PR DESCRIPTION
Add `urdf_parsing::` prefix to parsePose to avoid ambiguity with urdfdom 4.0.0.

Port of https://github.com/dartsim/dart/pull/1779.